### PR TITLE
Use schema:ListItem to order paper authors

### DIFF
--- a/dev/article.html
+++ b/dev/article.html
@@ -35,45 +35,97 @@
                 </p>
                 <h2><span property="dc:title">Nucleation and growth of new particles in Po Valley, Italy</span></h2>
                 <p>
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">A.</span> <span property="foaf:family_name">Hamed</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">J.</span> <span property="foaf:family_name">Joutsensaari</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">S.</span> <span property="foaf:family_name">Mikkonen</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">L.</span> <span property="foaf:family_name">Sogacheva</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">M.</span> <span property="foaf:family_name">Dal Maso</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><a href="https://orcid.org/0000-0003-3464-7825" property="vivo:orcidId"><span property="foaf:givenname">M.</span> <span property="foaf:family_name">Kulmala</span></a></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">F.</span> <span property="foaf:family_name">Cavalli</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">S.</span> <span property="foaf:family_name">Fuzzi</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">M. C.</span> <span property="foaf:family_name">Facchini</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">S.</span> <span property="foaf:family_name">Decesari</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">M.</span> <span property="foaf:family_name">Mircea</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><span content="" property="vivo:orcidId"><span property="foaf:givenname">K. E. J.</span> <span property="foaf:family_name">Lehtinen</span></span></span
-                    >,
-                    <span property="dc:creator" typeof="foaf:Person"
-                        ><a href="https://orcid.org/0000-0002-1657-2383" property="vivo:orcidId"><span property="foaf:givenname">A.</span> <span property="foaf:family_name">Laaksonen</span></a></span
-                    >
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="1" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">A.</span>
+                            <span property="foaf:family_name">Hamed</span>
+                        </span> 
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="2" />
+                        <span content="" property="vivo:orcidId"> 
+                            <span property="foaf:givenname">J.</span> 
+                            <span property="foaf:family_name">Joutsensaari</span> 
+                        </span> 
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="3" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">S.</span> 
+                            <span property="foaf:family_name">Mikkonen</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="4" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">L.</span> 
+                            <span property="foaf:family_name">Sogacheva</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="5" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">M.</span> 
+                            <span property="foaf:family_name">Dal Maso</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="6" />
+                        <a href="https://orcid.org/0000-0003-3464-7825" property="vivo:orcidId">
+                            <span property="foaf:givenname">M.</span> 
+                            <span property="foaf:family_name">Kulmala</span>
+                        </a>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="7" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">F.</span> 
+                            <span property="foaf:family_name">Cavalli</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="8" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">S.</span> 
+                            <span property="foaf:family_name">Fuzzi</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="9" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">M. C.</span>
+                            <span property="foaf:family_name">Facchini</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="10" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">S.</span> 
+                            <span property="foaf:family_name">Decesari</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="11" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">M.</span> 
+                            <span property="foaf:family_name">Mircea</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="12" />
+                        <span content="" property="vivo:orcidId">
+                            <span property="foaf:givenname">K. E. J.</span> 
+                            <span property="foaf:family_name">Lehtinen</span>
+                        </span>
+                    </span>,
+                    <span property="dc:creator" typeof="foaf:Person schema:ListItem">
+                        <meta property="schema:position" content="13" />
+                        <a href="https://orcid.org/0000-0002-1657-2383" property="vivo:orcidId">
+                            <span property="foaf:givenname">A.</span> 
+                            <span property="foaf:family_name">Laaksonen</span>
+                        </a>
+                    </span>
                 </p>
                 <p>
                     <span property="dc:isPartOf" typeof="bibo:Journal">

--- a/dev/orkg.ipynb
+++ b/dev/orkg.ipynb
@@ -2,12 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from utils import save_dataset, save_paper\n",
     "import pandas as pd\n",
+    "from rdflib import Graph\n",
     "from orkg import ORKG"
    ]
   },
@@ -37,16 +38,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=N61a08231321548ec84b9a42cd38558a6 (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=N779c684f3a79445cbf5605aff183b16d (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -60,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 3,
    "metadata": {
     "scrolled": true
    },
@@ -122,55 +123,81 @@
       "            orkg:yields orkg:R24346,\n",
       "                orkg:R24381 ] ;\n",
       "    orkg:hasResearchField orkg:R145 ;\n",
-      "    dc:creator [ a foaf:Person ;\n",
+      "    dc:creator [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"2\"@en ;\n",
       "            vivo:orcidId \"\"@en ;\n",
       "            foaf:family_name \"Joutsensaari\"@en ;\n",
       "            foaf:givenname \"J.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
-      "            vivo:orcidId \"\"@en ;\n",
-      "            foaf:family_name \"Hamed\"@en ;\n",
-      "            foaf:givenname \"A.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
-      "            vivo:orcidId <https://orcid.org/0000-0003-3464-7825> ;\n",
-      "            foaf:family_name \"Kulmala\"@en ;\n",
-      "            foaf:givenname \"M.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
-      "            vivo:orcidId \"\"@en ;\n",
-      "            foaf:family_name \"Fuzzi\"@en ;\n",
-      "            foaf:givenname \"S.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"4\"@en ;\n",
       "            vivo:orcidId \"\"@en ;\n",
       "            foaf:family_name \"Sogacheva\"@en ;\n",
       "            foaf:givenname \"L.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
-      "            vivo:orcidId \"\"@en ;\n",
-      "            foaf:family_name \"Lehtinen\"@en ;\n",
-      "            foaf:givenname \"K. E. J.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
-      "            vivo:orcidId \"\"@en ;\n",
-      "            foaf:family_name \"Mircea\"@en ;\n",
-      "            foaf:givenname \"M.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"3\"@en ;\n",
       "            vivo:orcidId \"\"@en ;\n",
       "            foaf:family_name \"Mikkonen\"@en ;\n",
       "            foaf:givenname \"S.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
-      "            vivo:orcidId <https://orcid.org/0000-0002-1657-2383> ;\n",
-      "            foaf:family_name \"Laaksonen\"@en ;\n",
-      "            foaf:givenname \"A.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
-      "            vivo:orcidId \"\"@en ;\n",
-      "            foaf:family_name \"Decesari\"@en ;\n",
-      "            foaf:givenname \"S.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"9\"@en ;\n",
       "            vivo:orcidId \"\"@en ;\n",
       "            foaf:family_name \"Facchini\"@en ;\n",
       "            foaf:givenname \"M. C.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"10\"@en ;\n",
+      "            vivo:orcidId \"\"@en ;\n",
+      "            foaf:family_name \"Decesari\"@en ;\n",
+      "            foaf:givenname \"S.\"@en ],\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"13\"@en ;\n",
+      "            vivo:orcidId <https://orcid.org/0000-0002-1657-2383> ;\n",
+      "            foaf:family_name \"Laaksonen\"@en ;\n",
+      "            foaf:givenname \"A.\"@en ],\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"5\"@en ;\n",
       "            vivo:orcidId \"\"@en ;\n",
       "            foaf:family_name \"Dal Maso\"@en ;\n",
       "            foaf:givenname \"M.\"@en ],\n",
-      "        [ a foaf:Person ;\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"6\"@en ;\n",
+      "            vivo:orcidId <https://orcid.org/0000-0003-3464-7825> ;\n",
+      "            foaf:family_name \"Kulmala\"@en ;\n",
+      "            foaf:givenname \"M.\"@en ],\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"1\"@en ;\n",
+      "            vivo:orcidId \"\"@en ;\n",
+      "            foaf:family_name \"Hamed\"@en ;\n",
+      "            foaf:givenname \"A.\"@en ],\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"11\"@en ;\n",
+      "            vivo:orcidId \"\"@en ;\n",
+      "            foaf:family_name \"Mircea\"@en ;\n",
+      "            foaf:givenname \"M.\"@en ],\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"12\"@en ;\n",
+      "            vivo:orcidId \"\"@en ;\n",
+      "            foaf:family_name \"Lehtinen\"@en ;\n",
+      "            foaf:givenname \"K. E. J.\"@en ],\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"8\"@en ;\n",
+      "            vivo:orcidId \"\"@en ;\n",
+      "            foaf:family_name \"Fuzzi\"@en ;\n",
+      "            foaf:givenname \"S.\"@en ],\n",
+      "        [ a schema:ListItem,\n",
+      "                foaf:Person ;\n",
+      "            schema:position \"7\"@en ;\n",
       "            vivo:orcidId \"\"@en ;\n",
       "            foaf:family_name \"Cavalli\"@en ;\n",
       "            foaf:givenname \"F.\"@en ] ;\n",
@@ -183,7 +210,7 @@
       "    bibo:pageEnd \"376\"@en ;\n",
       "    bibo:pageStart \"355\"@en ;\n",
       "    bibo:volume \"7\"@en ;\n",
-      "    schema:dateModified \"2019-11-06T12:57:08.648000+00:00\"^^xsd:dateTime ;\n",
+      "    schema:dateModified \"2019-11-06T17:09:59.094000+00:00\"^^xsd:dateTime ;\n",
       "    owl:sameAs <https://reddine.solid.community/public/hamed07nucleation.html> .\n",
       "\n",
       "\n"
@@ -196,14 +223,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'id': 'R24401', 'label': 'Nucleation and growth of new particles in Po Valley, Italy', 'classes': ['Paper'], 'shared': 0, 'created': '2019-11-06T12:57:36.561'}\n"
+      "{'id': 'R25219', 'label': 'Nucleation and growth of new particles in Po Valley, Italy', 'created_at': '2019-11-06T17:10:35.794Z', 'classes': ['Paper'], 'shared': 0}\n"
      ]
     }
    ],
@@ -211,20 +238,6 @@
     "paper = save_paper(g)\n",
     "print(paper.content)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/dev/utils.py
+++ b/dev/utils.py
@@ -111,12 +111,16 @@ def getAuthors(g):
         PREFIX bibo: <http://purl.org/ontology/bibo/>
         PREFIX dc: <http://purl.org/dc/terms/>
         PREFIX foaf: <http://xmlns.com/foaf/0.1/>
-        SELECT ?firstname ?lastname WHERE {
+        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+        SELECT ?firstname ?lastname
+        WHERE {
           ?a a bibo:Article .                              
           ?a dc:creator ?c .
           ?c foaf:givenname ?firstname .
           ?c foaf:family_name ?lastname .
+          ?c schema:position ?position .
         }
+        ORDER BY xsd:integer(?position)
     """).iterrows()]
 
 def getLabelOfNode(g,nodeID):


### PR DESCRIPTION
This update uses [schema:ListItem](https://schema.org/ListItem) to order paper authors, and then gets the ordered list of authors using this SPARL query :

```SQL
PREFIX bibo: <http://purl.org/ontology/bibo/>
PREFIX dc: <http://purl.org/dc/terms/>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
SELECT ?firstname ?lastname
WHERE {
    ?a a bibo:Article .                              
    ?a dc:creator ?c .
    ?c foaf:givenname ?firstname .
    ?c foaf:family_name ?lastname .
    ?c schema:position ?position .
}
ORDER BY xsd:integer(?position)
```